### PR TITLE
[이동혁] 파일등록 오류 수정 [HMS]

### DIFF
--- a/backend/src/main/java/com/example/demo/entity/hotel/Hotel.java
+++ b/backend/src/main/java/com/example/demo/entity/hotel/Hotel.java
@@ -26,7 +26,7 @@ public class Hotel {
 
     @Convert(converter = HotelConvert.class)
     private List<String> hotelInfo;
-
+    /*
     @Column(nullable = false)
     private String postcode;
 
@@ -39,10 +39,14 @@ public class Hotel {
     // 참고항목
     @Column(nullable = false)
     private String extraAddress;
+    */
 
-    @Convert(converter = HotelConvert.class)
-    private List<String> filePath;
-    /*@Column(nullable = false) // default 255
+    @Column(nullable = false)
+    private String totalAddress;
+
+    /*@Convert(converter = HotelConvert.class)
+    private List<String> filePath;*/
+    @Column(nullable = false) // default 255
     private String hotelImgPath1;
     @Column(nullable = false)
     private String hotelImgPath2;
@@ -60,8 +64,7 @@ public class Hotel {
     private String hotelImgPath8;
     @Column
     private String hotelImgPath9;
-    @Column
-    private String hotelImgPath10;*/
+
 
     //@Column(length = 300, nullable = false)
     //private String openKakaotalk;

--- a/backend/src/main/java/com/example/demo/service/hotel/HotelServiceImpl.java
+++ b/backend/src/main/java/com/example/demo/service/hotel/HotelServiceImpl.java
@@ -28,7 +28,7 @@ public class HotelServiceImpl implements HotelService {
     @Override
     public void register(Hotel hotel, List<MultipartFile> files) throws Exception {
 
-        List<String> filePath = new ArrayList<>();
+        List<String> filePathList = new ArrayList<>();
         try {
             if (files != null) {
                 UUID uuid = UUID.randomUUID();
@@ -42,17 +42,49 @@ public class HotelServiceImpl implements HotelService {
                     saveFile.write(multipartFile.getBytes());
                     saveFile.close();
 
-                    filePath.add(fileName);
+                    filePathList.add(fileName);
+
                 }
             }
         }catch (Exception e) {
             log.info("Upload Fail!!!");
         }
 
-        hotel.setFilePath(filePath);
+        for(int i = 0; i < filePathList.size(); i++) {
+            switch (i){
+                case 0:
+                     hotel.setHotelImgPath1(filePathList.get(i));
+                break;
+                case 1:
+                    hotel.setHotelImgPath2(filePathList.get(i));
+                    break;
+                case 2:
+                    hotel.setHotelImgPath3(filePathList.get(i));
+                    break;
+                case 3:
+                    hotel.setHotelImgPath4(filePathList.get(i));
+                    break;
+                case 4:
+                    hotel.setHotelImgPath5(filePathList.get(i));
+                    break;
+                case 5:
+                    hotel.setHotelImgPath6(filePathList.get(i));
+                    break;
+                case 6:
+                    hotel.setHotelImgPath7(filePathList.get(i));
+                    break;
+                case 7:
+                    hotel.setHotelImgPath8(filePathList.get(i));
+                    break;
+                case 8:
+                    hotel.setHotelImgPath9(filePathList.get(i));
+                    break;
+            }
+
+        }
+
 
         hotelRepository.save(hotel);
-        System.out.println(hotelRepository.findAll());
     }
 
     @Override

--- a/frontend/src/components/hotel/HotelRegisterForm.vue
+++ b/frontend/src/components/hotel/HotelRegisterForm.vue
@@ -193,6 +193,7 @@ export default {
             }
 
             this.fileNum += this.$refs.files.files.length
+            console.log(this.fileNum)
             if(this.fileNum < 10){
                         for (let i = 0; i < this.$refs.files.files.length; i++) {
                             this.files = [
@@ -206,6 +207,7 @@ export default {
                      
             }else{
                 alert("최대 9장 까지 가능 합니다")
+                console.log(this.fileNum)
                 this.fileNum -= this.$refs.files.files.length
                 this.$refs.files.value = ''
             }  
@@ -237,7 +239,7 @@ export default {
         imgCancel(index) {
             //인덱스 어디부터 하나 삭제
             this.files.splice(index,1)
-            URL.revokeObjectURL
+            this.fileNum -= 1
             console.log(this.files)
         }
     }

--- a/frontend/src/components/hotel/HotelRegisterForm.vue
+++ b/frontend/src/components/hotel/HotelRegisterForm.vue
@@ -133,7 +133,8 @@ export default {
             extraAddress: '',
             files: [],
             notImage: ['','','','','','','','',''],
-            fileNum: 0
+            fileNum: 0,
+            totalAddress:''
         }
     },
     methods: {
@@ -178,15 +179,13 @@ export default {
       }).open();
          },
         onSubmit () {
-           
-            this.files = this.$refs.files.files
             const { hotelName, hotelInfo, postcode, address, detailAddress, extraAddress, files } = this
-            
-            this.$emit('submit', { hotelName, hotelInfo, postcode, address, detailAddress, extraAddress, files })
+            this.totalAddress = postcode + " " + address + detailAddress + extraAddress
+            const { totalAddress} = this
+            this.$emit('submit', { hotelName, hotelInfo, totalAddress ,files })
             
         },
            handleFilesUpload () {
-            console.log(this.$refs.files.files.length)
             if(this.$refs.files.files.length > 9){
                 alert("최대 9장 까지 가능 합니다")
                 this.$refs.files.value = ''
@@ -194,17 +193,17 @@ export default {
             }
 
             this.fileNum += this.$refs.files.files.length
-            console.log(this.files.length)
             if(this.fileNum < 10){
                         for (let i = 0; i < this.$refs.files.files.length; i++) {
                             this.files = [
                                 ...this.files,
                                 {
                                     file: this.$refs.files.files[i],
-                                    preview: URL.createObjectURL(this.$refs.files.files[i]),
+                                    preview: URL.createObjectURL(this.$refs.files.files[i])
                                 }
                             ]
                         }      
+                     
             }else{
                 alert("최대 9장 까지 가능 합니다")
                 this.fileNum -= this.$refs.files.files.length
@@ -240,8 +239,7 @@ export default {
             this.files.splice(index,1)
             URL.revokeObjectURL
             console.log(this.files)
-        }   
-        
+        }
     }
  
 }

--- a/frontend/src/views/hotel/HotelRegisterPage.vue
+++ b/frontend/src/views/hotel/HotelRegisterPage.vue
@@ -18,21 +18,18 @@ export default {
     },
     methods: {
         onSubmit (payload) {
-            const { hotelName, hotelInfo, postcode, address, detailAddress, extraAddress, files } = payload
+            const { hotelName, hotelInfo, totalAddress , files } = payload
             let formData = new FormData()
             let hotel = {
                     hotelName,
                     hotelInfo,
-                    postcode,
-                    address,
-                    detailAddress,
-                    extraAddress
+                    totalAddress
             }
       
             formData.append('hotel',new Blob([JSON.stringify(hotel)],{type: "application/json"}))
             
             for (let i = 0; i <  files.length; i++) {
-                formData.append('files',files[i])
+                formData.append('files',files[i].file)
             }
 
            


### PR DESCRIPTION
1. filepath 경로 list저장하니 사진 4장이상 db에 저장되는 너무 값이 길다고 오류 생겨서 수정
2. 사진 파일 this.$refs.files.files로 보내던거 this.files[i].file로 보내서 일정하게 file값 유지하게 만들어서 보냄
>>> this.$refs.files.files는 등록할 때마다 등록한 애들으로 새롭게 갱신 됨
3. 엔티티에 파일경로 컬럼 9개 추가로 파일경로 등록에 switch사용