### PR TITLE
[손현지] 숙소상세보기 v-date-picker 삽입위치 RoomReadForm으로 이동 [HDU]

### DIFF
--- a/frontend/src/components/hotelDetail/HotelReadForm.vue
+++ b/frontend/src/components/hotelDetail/HotelReadForm.vue
@@ -125,14 +125,15 @@
               <p>{{ mHotel.totalAddress }}</p>
             </td>
           </tr>
-          <td colspan="2" align="center">
+          <tr>
+            <td colspan="2" align="center">
             <kakao-map-api
               v-if="Object.keys(mHotel).length !== 0"
               :mHotel="mHotel"
             />
             <br />
           </td>
-          <tr></tr>
+          </tr>
 
           <tr>
             <td colspan="2">
@@ -140,7 +141,6 @@
             </td>
           </tr>
         </table>
-        <br />
       </form>
     </v-container>
   </div>

--- a/frontend/src/components/hotelDetail/RoomReadForm.vue
+++ b/frontend/src/components/hotelDetail/RoomReadForm.vue
@@ -1,14 +1,35 @@
 <template>
-  <v-container>
+  <v-container>    
     <table style="width: 80%">
+
+      <!-- 검색 컴포넌트 분리 원한다면 여기서부터-->
       <tr>
         <td>
           <h1 align="left">객실 소개</h1>
         </td>
+        <!-- 검색창 -->
+        <td align="right">
+            <v-col cols="12" xs="12" sm="6" md="4">
+              <v-menu class="menu1" :close-on-content-click="false" transition="scale-transition"
+                  offset-y>
+                  <template v-slot:activator="{ on, attrs }">
+                      <v-text-field class="DateSearch"  label="날짜 선택" v-model="planDate"
+                          prepend-icon="mdi-calendar" v-bind="attrs" v-on="on"
+                          rounded solo readonly></v-text-field>
+                  </template>
+                  <v-date-picker v-model="dates" 
+                                  :min="new Date(Date.now() - new Date().getTimezoneOffset() * 60000).toISOString().substr(0,10)" range
+                                  >
+                  </v-date-picker>
+              </v-menu>
+          </v-col>
+        </td>
       </tr>
-      <tr>
-        <!-- 객실 란 컴포넌트 분리하여 작업 중!-->
-        <td>
+      <!-- 여기까지 주석 혹은 삭제 -->
+
+
+      <tr> <!-- 객실 란-->
+        <td colspan="2">
           <v-container>
             <v-col v-for="(item, i) in roomList" :key="i">
               <v-card
@@ -134,14 +155,31 @@
 export default {
   name: "RoomReadForm",
   components: {},
+    data: () => ({
+        dates: [],
+    }),
   props: {
     roomList: {
       type: Array,
     },
   },
+    computed: {
+        planDate () {
+            if(this.dates.length == 2) {
+                if(this.dates[0] >= this.dates[1]){
+                    alert ('다시 선택하세요')
+                    this.initDates()
+                }
+            }
+            return this.dates.join(' ~ ')
+        },
+    },
   methods: {
     goReserv() {},
-  },
+    initDates() {
+        return this.dates = []
+    }
+},
 };
 </script>
 

--- a/frontend/src/components/hotelDetail/SearchCalenderForm.vue
+++ b/frontend/src/components/hotelDetail/SearchCalenderForm.vue
@@ -1,12 +1,27 @@
+<!-- 다시 살리게 될 일 생길까봐 일단 삭제는 하지 않고 살려둠-->
 <template>
     <v-container>
-        <table>
-            <tr> <!-- 검색 날짜 -->
+        <table style="width: 80%">
+            <tr>
                 <td>
-                    <v-date-picker v-model="dates"
-                                    :min="new Date(Date.now() - new Date().getTimezoneOffset() * 60000).toISOString().substr(0,10)" range
-                                    >
-                    </v-date-picker>                   
+                <h1 align="left">객실 소개</h1>
+                </td>
+                <!-- 검색창 -->
+                <td align="right">
+                    <v-col cols="12" xs="12" sm="6" md="4">
+                    <v-menu class="menu1" :close-on-content-click="false" transition="scale-transition"
+                        offset-y>
+                        <template v-slot:activator="{ on, attrs }">
+                            <v-text-field class="DateSearch"  label="날짜 선택" v-model="planDate"
+                                prepend-icon="mdi-calendar" v-bind="attrs" v-on="on"
+                                rounded solo readonly></v-text-field>
+                        </template>
+                        <v-date-picker v-model="dates" 
+                                        :min="new Date(Date.now() - new Date().getTimezoneOffset() * 60000).toISOString().substr(0,10)" range
+                                        >
+                        </v-date-picker>
+                    </v-menu>
+                </v-col>
                 </td>
             </tr>
         </table>

--- a/frontend/src/views/hotelDetail/HotelReadPage.vue
+++ b/frontend/src/views/hotelDetail/HotelReadPage.vue
@@ -1,8 +1,11 @@
 <template>
   <div align="center">
     <m-hotel-read-form :mHotel="mHotel" />
-    <!-- HotelReadPage로 옮긴다면 kakaoMapAPI위치는 여기에   -->
-    <m-search-calender-form/>
+    <!-- <m-search-calender-form/>
+     SearchCalenderForm.vue 해당 컴포넌트 내역을 우선
+     RoomReadForm 내로 이동시켰습니다.
+     검색 작업상 내역을 분리하는 편이 좋다면 주석만 풀어주시면 됩니다.
+    -->
     <m-room-read-form :roomList="roomList" />
     <!-- 주석 -->
     <!-- <m-review-read-form :mReview="mReview"/>
@@ -14,7 +17,7 @@
 import { mapActions, mapState } from "vuex";
 import MHotelReadForm from "@/components/hotelDetail/HotelReadForm.vue";
 import MRoomReadForm from "@/components/hotelDetail/RoomReadForm.vue";
-import MSearchCalenderForm from"@/components/hotelDetail/SearchCalenderForm.vue"
+//import MSearchCalenderForm from"@/components/hotelDetail/SearchCalenderForm.vue"
 
 import axios from "axios";
 export default {
@@ -33,7 +36,7 @@ export default {
   components: {
     MHotelReadForm,
     MRoomReadForm,
-    MSearchCalenderForm
+    //MSearchCalenderForm
 },
   computed: {
     ...mapState(["mHotel"]),


### PR DESCRIPTION
**2022.07.01**
- 달력만 보이는 것이 아니라 메인 서치와 같이 검색창 형태로 보이도록 변경
- SearchCalenderForm으로 따로 분리했던 것을 RoomReadForm내로 옮김
  - 만약 SearchCalenderForm에서 그대로 쓰고싶다면 주석처리된 부분만 지우면 됨