### PR TITLE
[손현지] 사업자 - 숙소&객실 상세보기 UI [APU]

### DIFF
--- a/frontend/src/components/business/ManageReservList.vue
+++ b/frontend/src/components/business/ManageReservList.vue
@@ -1,39 +1,16 @@
 <template>
   <v-container>
-    <template>
-      <!-- 서치 시간없으면 빼도 OK -->
-      <div align="center" style="width: 80%">
-        <v-col>
-          <v-row>
-            <v-text-field
-              class="search"
-              v-model="keyWord"
-              label="Search"
-              placeholder="키워드를 입력해주세요."
-              single-line
-              hide-details
-            ></v-text-field>
-            <v-col cols="2" md="1">
-              <v-btn id="searchBtn" dark small>
-                <v-icon> mdi-magnify </v-icon>
-              </v-btn>
-            </v-col>
-          </v-row>
-        </v-col>
-      </div>
-    </template>
     <br />
-
-    <template>
       <div>
         <table style="width: 80%">
           <tr>
             <th align="center" width="160">체크인</th>
             <th align="center" width="160">체크아웃</th>
+            <th align="center" width="180">예약상태</th>
             <th align="center" width="300">객실명</th>
             <th align="center" width="150">고객명</th>
             <th align="center" width="150">숙박인원</th>
-            <th align="center" width="100"></th>
+            <th align="center" width="200"></th>
           </tr>
           <tbody>
             <tr
@@ -47,7 +24,7 @@
 
             <tr
               v-else
-              v-for="(ceoBookingList, idx) in ceoBookingLists"
+              v-for="(ceoBookingList, idx) in paginatedData"
               :key="idx"
             >
               <td align="center">
@@ -58,7 +35,10 @@
                 <!-- 체크아웃 날짜 -->
                 <span>{{ ceoBookingList.endDate }}</span>
               </td>
-
+              <td align="center">
+                <!-- 예약상태 -->
+                <span>{{ ceoBookingList.status }}</span>
+              </td>
               <td align="center">
                 <!-- 객실명 -->
                 <v-col>
@@ -80,7 +60,27 @@
           </tbody>
         </table>
       </div>
-    </template>
+
+<br>
+
+      <div class="page-box">
+              <div class="btn-cover">
+                  <button :disabled="pageNum === 0" @click="prevPage" class="page-btn">
+                      <v-icon> mdi-chevron-left </v-icon>
+                  </button>
+                  &ensp;
+
+                  <span>{{ pageNum + 1 }} / {{ pageCount }}</span>
+                  
+                  &ensp;
+                  <button :disabled="pageNum >= pageCount - 1" @click="nextPage" class="page-btn">
+                      <v-icon> mdi-chevron-right </v-icon>  
+                  </button>
+              </div>
+        </div>
+
+<br>
+
 
     <!--테이블 페이지네이션-->
   </v-container>
@@ -102,22 +102,100 @@ export default {
       type: Array,
       required: true,
     },
+    pageSize: {
+      type: Number,
+      required: false,
+      default: 5
+    }
   },
   data() {
-    return {};
+    return {
+      pageNum: 0,
+    };
   },
+  computed: {
+    pageCount () {
+                let listLeng = this.ceoBookingLists.length,
+                    listSize = this.pageSize,
+                    page = Math.floor(listLeng / listSize);
+                if (listLeng % listSize > 0) page += 1
+                return page;
+            },
+            paginatedData () {
+                const start = this.pageNum * this.pageSize,
+                        end = start + this.pageSize;
+                return this.ceoBookingLists.slice(start, end);
+                
+            }
+  },
+  methods: {
+    nextPage () {
+    this.pageNum += 1;
+    },
+    prevPage () {
+    this.pageNum -= 1;
+    },
+}
 };
 </script>
 
 <style scoped>
+.board-list {
+  margin-top: 20px;
+  /*margin-left: 50px;
+  margin-right: 50px; */
+}
+/* 링크 색상 (중요하지 않음) */
+a {
+  text-decoration: none;
+  color: #333;
+}
+/* 테이블 색상 (중요하지 않음) */
+table {
+  width: 95%;
+  border-collapse: collapse;
+}
 th {
-  border-bottom: 2px solid #444444;
+  background: #54658a;
+  color: #fff;
+  font-size: 15px;
+  border: 1px solid #dbdbdb;
+  height: 45px;
+  padding: 5px 20px;
 }
 td {
+  border: 1px solid #dbdbdb;
+  color: rgb(34, 34, 34);
+  height: 42px;
+  padding: 5px 20px;
+  font-size:13px;
+}
+tr:nth-of-type(odd) { 
+	background: rgb(243, 243, 243); 
   vertical-align: middle;
 }
 #search {
   width: 80%;
+  margin: 5px auto;
+  height: 30px;
+  text-align: center;
+}
+.page-box a.btn {
+  display:inline-block;
+  padding: 3px 5px;
+  font-size: 15px;
+  border: 1px solid #dbdbdb;
+  color: #333;
+}
+.page-box a.btn.on {
+  background-color: #dbdbdb;
+}
+.btn {
+  position: sticky;
+  text-decoration: none;
+}
+#search{
+    width:50%;
 }
 #roomImg {
   width: 100px;

--- a/frontend/src/components/business/ReservDetail.vue
+++ b/frontend/src/components/business/ReservDetail.vue
@@ -4,7 +4,7 @@
       <!-- 쓰는 파일 -->
       <v-dialog v-model="dialog" width="800px">
         <template v-slot:activator="{ on }">
-          <v-btn style="color: black" v-on="on"> 상세보기 </v-btn>
+           <button id="button" v-on="on"> 상세보기 </button>
         </template>
         <v-card align="center">
           <v-card-title id="title">
@@ -122,7 +122,7 @@
                                     하지만 그냥 고객이 예약한 인원수로 바꿔도 상관없습니다. -->
                       </td>
                       <td align="center">
-                        <v-btn id="delButton" @click="onDelete"> X </v-btn>
+                        <v-btn id="delButton" @click="onDelete"> 예약취소 </v-btn>
                       </td>
                     </tr>
                   </table>
@@ -133,7 +133,6 @@
           <br />
           <v-card-actions>
             <v-spacer></v-spacer>
-            <v-btn> 수정 </v-btn>
             <v-btn @click="cancel"> 닫기 </v-btn>
             <v-spacer></v-spacer>
           </v-card-actions>
@@ -183,6 +182,20 @@ export default {
   border-radius: 50px;
   background-color: brown;
   color: white;
-  font-size: 20px;
+  font-size: 15px;
+}
+
+#button {
+    text-decoration: none;
+    position: relative;
+    padding: 0 15px;
+    color: #404040;
+    font-weight: 600;
+    font-size: 15px;
+    line-height: 29px;
+}
+
+#button:hover {
+  color: #569aff;
 }
 </style>

--- a/frontend/src/components/detailSearch/CommonSearch.vue
+++ b/frontend/src/components/detailSearch/CommonSearch.vue
@@ -23,24 +23,19 @@
         <v-container justify="center" >
          <v-row>
             <v-col>
-            <div class="btn-cover" align="center">
-                <v-btn
-                    :disabled="pageNum === 0"
-                    @click="prevPage"
-                    class="page-btn">
-                이전
-                </v-btn>
-                <span class="page-count"
-                >{{ pageNum + 1 }} / {{ pageCount }} 페이지</span
-                >
-                <v-btn
-                    :disabled="pageNum >= pageCount - 1"
-                    @click="nextPage"
-                    class="page-btn"
-                >
-                다음
-                </v-btn>
-            </div>
+        <div class="btn-cover">
+            <button :disabled="pageNum === 0" @click="prevPage" class="page-btn">
+                <v-icon> mdi-chevron-left </v-icon>
+            </button>
+            &ensp;
+
+                <span>{{ pageNum + 1 }} / {{ pageCount }} 페이지</span>
+
+            &ensp;
+            <button :disabled="pageNum >= pageCount - 1" @click="nextPage" class="page-btn">
+                <v-icon> mdi-chevron-right </v-icon>  
+            </button>
+        </div>
             </v-col>
          </v-row>
         </v-container>
@@ -65,7 +60,7 @@ export default {
     pageSize: {
       type: Number,
       required: false,
-      default: 4,
+      default: 6,
     }
   },
   data() {
@@ -151,4 +146,6 @@ export default {
 #spaninfo{
   margin: 1%;
 }
+
+
 </style>

--- a/frontend/src/components/detailSearch/TagSearchForm.vue
+++ b/frontend/src/components/detailSearch/TagSearchForm.vue
@@ -33,7 +33,7 @@
                 
                 &ensp;
                 
-                <span class="page-count"
+                <span
                 >{{ pageNum + 1 }} / {{ pageCount }} 페이지</span
                 >
 
@@ -68,7 +68,7 @@ export default {
     pageSize: {
       type: Number,
       required: false,
-      default: 4,
+      default: 6,
     }
   },
   data() {

--- a/frontend/src/components/hotel/HotelList.vue
+++ b/frontend/src/components/hotel/HotelList.vue
@@ -51,7 +51,7 @@
 
 <br>
 
-<v-btn class="btn" @click="deleteHotel()">삭제</v-btn>
+<button id="button" @click="deleteHotel()">삭제</button>
 
 <br>
 

--- a/frontend/src/components/hotel/HotelRead.vue
+++ b/frontend/src/components/hotel/HotelRead.vue
@@ -1,48 +1,112 @@
 <template>
-    <div>
+    <v-container class="board-list">
         <!-- 기본정보 -->
         <div class="hotelName">
-            <h3>기본정보</h3>
-            <hr>
-            <label class="hotelNameLabel">숙소명</label>
-            <input type="text" class="hotelNameBox" :value="bmHotel.hotelName" readonly/>
+
+            <table style="width: 100%">
+                  <colgroup>
+                    <col class="label">
+                    <col class="content">
+                </colgroup>
+                <tr>
+                    <td colspan="2">
+                        <h3>기본정보</h3>
+                    </td>
+                </tr>
+
+                <tr>
+                    <td align="center" id="title2">숙소명</td>
+                    <td class="content">
+                        <input type="text" class="hotelNameBox" :value="bmHotel.hotelName" readonly/>
+                    </td>
+                </tr>
+            </table>
+
         </div>
 
         <!-- 시설정보 -->
         <div class="hotelInfo">
-            <h3>시설정보</h3>
-            <hr>
-            <label class="hotelInfoLabel">옵션</label>    
-            <input type="text" class="hotelInfobox" :value="bmHotel.hotelInfo" readonly/>
+
+            <table style="width: 100%">
+                  <colgroup>
+                    <col class="label">
+                    <col class="content">
+                </colgroup>
+                <tr>
+                    <td colspan="2">
+                        <h3>시설정보</h3>
+                    </td>
+                </tr>
+
+                <tr>
+                    <td align="center" id="title2">옵션</td>
+                    <td class="content">
+                        <input type="text" class="hotelInfobox" style="width: 100%" :value="bmHotel.hotelInfo" readonly/>
+                        
+                    </td>
+                </tr>
+            </table>
+
         </div>
         
         <!-- 위치정보 -->
         <div class="hotelAddress">
-            <h3>위치정보</h3>
-            <hr>
-            <div class="adApi">
-                <label>우편번호</label>
-                <input type="text" id="postcode" :value="bmHotel.postcode" readonly/><br>
-                <label>주소</label>
-                <input type="text" id="address" :value="bmHotel.totalAddress" readonly/>
-            </div>
+            <table style="width: 100%">
+                  <colgroup>
+                    <col class="label">
+                    <col class="content">
+                </colgroup>
+                <tr>
+                    <td colspan="2">
+                        <h3>위치정보</h3>
+                    </td>
+                </tr>
+
+                <tr>
+                    <td align="center" id="title2">우편번호</td>
+                    <td class="content">
+                        <input type="text" class="hotelInfobox" style="width: 100%" :value="bmHotel.postcode" readonly/>
+                        
+                    </td>
+                </tr>
+                <tr>
+                    <td align="center" id="title2">주소</td>
+                    <td class="content">
+                        <input type="text" class="hotelInfobox" style="width: 100%" :value="bmHotel.totalAddress" readonly/>
+                        
+                    </td>
+                </tr>                
+            </table>
+
         </div>
         
         <!-- 이미지 -->
         <div class="hotelImg">
-            <h3>이미지</h3>
-            <hr>
-            <div>
-                <v-container>
-                    <v-img width="100px" height="100px" v-for="(item, index) in bmHotel.hotelImages" :key=index
-                    :src="require(`@/assets/hotelImg/${item}`)"></v-img>
-                </v-container>
-            </div>
+
+            <table style="width: 100%">
+                  <colgroup>
+                    <col class="label">
+                    <col class="content">
+                </colgroup>
+                <tr>
+                    <td colspan="2">
+                        <h3>이미지</h3>
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <v-container>
+                            <v-row>
+                            <v-img width="100px" height="100px" v-for="(item, index) in bmHotel.hotelImages" :key=index
+                            :src="require(`@/assets/hotelImg/${item}`)"></v-img>
+                            </v-row>
+                        </v-container>
+                    </td>
+                </tr>
+            </table>
+
         </div>
-
-
-
-    </div>
+    </v-container>
 </template>
 
 <script>
@@ -58,6 +122,29 @@ export default {
 </script>
 
 <style scoped>
+/* 컬럼의 너비 */
+.label {width: 20%;}
+.content { /* 자동으로 맞춰집니다 */ }
+
+h3 {
+    margin: 10px;
+    color:#18225c;
+    padding: 10px 0px 10px 2px;
+}
+#title2 {
+    color:#6e91b3;
+    background-color: #e4f1f8;
+    font-weight: bold;
+    width: 95px;
+}
+
+
+td {
+  color: rgb(34, 34, 34);
+  font-size:14px;
+  height: 30px;
+}
+
 div {
   -webkit-user-select:none;
   -moz-user-select:none;
@@ -66,9 +153,6 @@ div {
 }
 a {
     text-decoration: none;
-}
-h3 {
-    margin: 10px;
 }
 .hotelName {
     margin: 50px 50px 10px 50px;
@@ -88,7 +172,6 @@ h3 {
     padding: 5px 8px;
     margin: 30px;
     font-size: 14px;
-    font-weight: bold;
     outline: none;
 }
 .hotelInfo {
@@ -103,7 +186,6 @@ h3 {
     padding: 5px 8px;
     margin: 30px;
     font-size: 14px;
-    font-weight: bold;
     outline: none;
 }
 .hotelAddress {
@@ -118,7 +200,6 @@ input[id="postcode"] {
     padding: 5px 8px;
     margin: 30px 0px 0px 35px;
     font-size: 14px;
-    font-weight: bold;
     outline: none;
 }
 input[id="address"] {
@@ -126,7 +207,6 @@ input[id="address"] {
     padding: 5px 8px;
     margin: 0px 0px 0px 35px;
     font-size: 14px;
-    font-weight: bold;
     outline: none;
 }
 .hotelImg {

--- a/frontend/src/components/hotelDetail/HotelReadForm.vue
+++ b/frontend/src/components/hotelDetail/HotelReadForm.vue
@@ -5,7 +5,7 @@
         <!-- 주석 -->
 
         <table style="width: 80%">
-          <tr align="right">
+          <tr align="right"> <!-- 좋아요 -->
             <td colspan="2">
               <v-btn  style="box-shadow:none; background:none;">
                 <!--이 태그 안에 @click=""해서 작업하시면 됩니다. -->
@@ -197,6 +197,11 @@ export default {
 </script>
 
 <style scoped>
+h1{
+  font-family: 'NanumSquareRound';  
+  color: #202020;
+}
+
 #inCard {
   border: 1px;
   color: black;
@@ -214,8 +219,21 @@ export default {
   padding: 6px;
   padding-left: 20px;
   padding-right: 20px;
-  border-radius: 5px;
-  background-color: lightgray;
+  background-color: #f8f8f8;
+  margin: 10px;
+  padding: 6px;
+  padding-left: 20px;
+  padding-right: 20px;
+  background-color: #f8f8f8;
+  display: inline-block;
+  position: relative;
+  border-radius: 20px;
+  text-decoration: none;
+  margin: 0.7em;
+  font-size: 1.0em;
+  font-weight: 500;
+  font-family: Pretendard,-apple-system,BlinkMacSystemFont,Open Sans,Helvetica Neue,sans-serif;;
+  color: #404040;
 }
 #myImg {
   width: 55px;

--- a/frontend/src/components/hotelDetail/HotelReadForm.vue
+++ b/frontend/src/components/hotelDetail/HotelReadForm.vue
@@ -7,10 +7,10 @@
         <table style="width: 80%">
           <tr align="right">
             <td colspan="2">
-              <v-btn>
+              <v-btn  style="box-shadow:none; background:none;">
                 <!--이 태그 안에 @click=""해서 작업하시면 됩니다. -->
                 <v-icon v-if="checkWish == false" @click="wish" > mdi-cards-heart </v-icon>
-                <v-icon v-if="checkWish == true" @click="wish" color="#ccbce3"> mdi-cards-heart </v-icon>
+                <v-icon v-if="checkWish == true" @click="wish" color="#e63668"> mdi-cards-heart </v-icon>
               </v-btn>
               &ensp;
             </td>
@@ -222,6 +222,7 @@ export default {
   height: 55px;
   border-radius: 25px;
 }
+
 /*table{
     border-collapse:collapse;
     border: 1px solid black;

--- a/frontend/src/components/hotelDetail/KakaoMapApi.vue
+++ b/frontend/src/components/hotelDetail/KakaoMapApi.vue
@@ -1,6 +1,6 @@
 <template>
     <div>
-        <div id="map" style="width:500px;height:400px;"></div>
+        <div id="map" style="width:70%;height:400px;"></div>
     </div>
     
 </template>
@@ -17,8 +17,9 @@ export default {
     data() {
         return{
             map: null,
-            geocoder: null
-        }
+            geocoder: null,
+            hotelInfo: [],
+}
     },
     methods: {
         initMap() {

--- a/frontend/src/components/hotelDetail/RoomReadForm.vue
+++ b/frontend/src/components/hotelDetail/RoomReadForm.vue
@@ -67,8 +67,10 @@
                     </table>
                     <table id="inCard" style="width: 42%; height: 190px">
                       <tr>
-                        <td>
-                          <p>{{ item.roomType }} &ensp;|&ensp; {{ item.personnel }}</p>
+                        <td style="vertical-align: bottom;">
+                          <v-row>
+                            <h4>{{ item.roomType }}</h4> <p> &ensp;|&ensp; {{ item.personnel }}</p>
+                          </v-row>
                         </td>
                       </tr>
                       <tr>
@@ -252,8 +254,6 @@ h1{
   color: #202020;
 }
 #tagSpan1 {
-  margin: 10px;
-  padding: 6px;
   padding-left: 20px;
   padding-right: 20px;
   background-color: #f8f8f8;

--- a/frontend/src/components/hotelDetail/RoomReadForm.vue
+++ b/frontend/src/components/hotelDetail/RoomReadForm.vue
@@ -68,12 +68,7 @@
                     <table id="inCard" style="width: 42%; height: 190px">
                       <tr>
                         <td>
-                          <p>{{ item.roomType }}</p>
-                        </td>
-                      </tr>
-                      <tr>
-                        <td>
-                          <p>{{ item.personnel }}</p>
+                          <p>{{ item.roomType }} &ensp;|&ensp; {{ item.personnel }}</p>
                         </td>
                       </tr>
                       <tr>
@@ -101,7 +96,7 @@
                               <tr>
                                 <v-dialog v-model="dialog" width="700px">
                                   <template v-slot:activator="{ on }">
-                                    <v-btn v-on="on" dark> 상세보기 </v-btn>
+                                    <v-btn id="button" v-on="on"> 상세보기 </v-btn>
                                   </template>
                                   <!-- slide를 넣어서 객실 사진 전부를 확인할 수 있도록 한다. -->
                                   <div class="slide-10d">
@@ -127,7 +122,7 @@
                                 <td>
                                   <br />
                                   <v-btn
-                                    id="button"
+                                    id="button2"
                                     @click="
                                       goReserv(item)
                                     "
@@ -252,16 +247,43 @@ export default {
 </script>
 
 <style scoped>
+h1{
+  font-family: 'NanumSquareRound';  
+  color: #202020;
+}
 #tagSpan1 {
   margin: 10px;
   padding: 6px;
   padding-left: 20px;
   padding-right: 20px;
-  border-radius: 5px;
-  background-color: lightgray;
+  background-color: #f8f8f8;
+  display: inline-block;
+  position: relative;
+  border-radius: 20px;
+  text-decoration: none;
+  margin: 0.7em;
+  font-weight: 500;
+  font-family: Pretendard,-apple-system,BlinkMacSystemFont,Open Sans,Helvetica Neue,sans-serif;;
   font-size: 12px;
   color: gray;
 }
+
+#button2 {
+    text-decoration: none;
+    background-color: #54658a;
+    position: relative;
+    padding: 0 15px;
+    color: #f8f8f8;
+    font-weight: 600;
+    font-size: 15px;
+    line-height: 29px;
+}
+
+#button2:hover {
+  background-color: #e63668;
+}
+
+
 /*table, th, td{
     border-collapse:collapse;
     border: 1px solid black;

--- a/frontend/src/components/reserv/MReservForm.vue
+++ b/frontend/src/components/reserv/MReservForm.vue
@@ -101,7 +101,7 @@
                 <td align="center">
                     <br>
         <!-- 약관 안내 체크에 빠진 것이 없고 + 결제 라디오 버튼 중 한 개를 반드시 선택해야 결제가 가능하다. -->
-                        <v-btn block id="button">
+                        <v-btn block id="button2">
                             결 제 하 기
                         </v-btn>
                 </td>
@@ -157,11 +157,21 @@ td {
     font-weight: bold;
     width: 95px;
 }
-#button {
+#button2 {
+    text-decoration: none;
     background-color: #54658a;
-    color: #fff;
-    font-weight: bold;
+    position: relative;
+    padding: 0 15px;
+    color: #f8f8f8;
+    font-weight: 600;
+    font-size: 15px;
+    line-height: 29px;
 }
+
+#button2:hover {
+  background-color: #e63668;
+}
+
 
 .check {
   width:15px;

--- a/frontend/src/components/room/RoomList.vue
+++ b/frontend/src/components/room/RoomList.vue
@@ -32,7 +32,7 @@
 </table>
 
 <br>
-<v-btn @click="deleteRoom()">삭제</v-btn>
+<button  id="button" @click="deleteRoom()">삭제</button>
 <br>
 <br>
 

--- a/frontend/src/components/room/RoomRead.vue
+++ b/frontend/src/components/room/RoomRead.vue
@@ -1,49 +1,141 @@
 <template>
-    <div>
+    <v-container>
         <!-- 기본정보 -->
         <div class="hotelName">
-            <h3>기본정보</h3>
+
+            <table style="width: 100%">
+                  <colgroup>
+                    <col class="label">
+                    <col class="content">
+                </colgroup>
+                <tr>
+                    <td colspan="2">
+                        <h3>기본정보</h3>
+                    </td>
+                </tr>
+
+                <tr>
+                    <td align="center" id="title2">객실명</td>
+                    <td class="content">
+                        <input type="text" class="hotelNameBox" :value="bmRoom.roomType" readonly/>
+                    </td>
+                </tr>
+            </table>
+
+
+         <!--   <h3>기본정보</h3>
             <hr>
             <label class="hotelNameLabel">객실명</label>
-            <input type="text" class="hotelNameBox" :value="bmRoom.roomType" readonly/>
+            <input type="text" class="hotelNameBox" :value="bmRoom.roomType" readonly/>-->
             
         </div>
 
         <!-- 시설정보 -->
         <div class="hotelInfo">
-            <h3>시설정보</h3>
+
+            <table style="width: 100%">
+                  <colgroup>
+                    <col class="label">
+                    <col class="content">
+                </colgroup>
+                <tr>
+                    <td colspan="2">
+                        <h3>시설정보</h3>
+                    </td>
+                </tr>
+
+                <tr>
+                    <td align="center" id="title2">옵션</td>
+                    <td class="content">
+                        <input type="text" class="hotelInfobox" style="width: 100%" :value="bmRoom.roomInfo" readonly/>
+                        
+                    </td>
+                </tr>
+            </table>
+
+        <!--    <h3>시설정보</h3>
             <hr>
             <label class="hotelInfoLabel">옵션</label>    
-            <input type="text" class="hotelInfobox" :value="bmRoom.roomInfo" readonly/>
+            <input type="text" class="hotelInfobox" :value="bmRoom.roomInfo" readonly/> -->
         </div>
         
+
         <!-- 위치정보 -->
         <div class="hotelAddress">
-            <h3>객실정보</h3>
+            <table style="width: 100%">
+                  <colgroup>
+                    <col class="label">
+                    <col class="content">
+                </colgroup>
+                <tr>
+                    <td colspan="2">
+                        <h3>객실정보</h3>
+                    </td>
+                </tr>
+
+                <tr>
+                    <td align="center" id="title2">인원수</td>
+                    <td class="content">
+                        <input type="text" class="hotelInfobox" style="width: 100%" :value="bmRoom.personnel" readonly/>
+                        
+                    </td>
+                </tr>
+                <tr>
+                    <td align="center" id="title2">가격</td>
+                    <td class="content">
+                        <input type="text" class="hotelInfobox" style="width: 100%" :value="bmRoom.price" readonly/>
+                        
+                    </td>
+                </tr>
+            </table>
+
+        <!--    <h3>객실정보</h3>
             <hr>
             <div class="adApi">
                 <label>인원수</label>
                 <input type="text" id="postcode" :value="bmRoom.personnel" readonly/><br>
                 <label>가격</label>
                 <input type="text" id="address" :value="bmRoom.price" readonly/>
-            </div>
+            </div> -->
         </div>
         
         <!-- 이미지 -->
         <div class="hotelImg">
-            <h3>이미지</h3>
+            <table style="width: 100%">
+                  <colgroup>
+                    <col class="label">
+                    <col class="content">
+                </colgroup>
+                <tr>
+                    <td colspan="2">
+                        <h3>이미지</h3>
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <v-container>
+                            <v-row>
+                            <v-img width="100px" height="100px" v-for="(image , idx) in bmRoom.roomImage" :key="idx" :src="require(`@/assets/roomImg/${image}`)"/>
+                            </v-row>
+                        </v-container>
+                    </td>
+                </tr>
+            </table>
+
+
+    <!--        <h3>이미지</h3>
             <hr>
             <div>
                 <v-container v-for="(image , idx) in bmRoom.roomImage" :key="idx">
                     <v-img width="100px" height="100px" :src="require(`@/assets/roomImg/${image}`)"/>
                 </v-container>
                 
-            </div>
+            </div> -->
         </div>
 
 
 
-    </div>
+    </v-container>
 </template>
 
 <script>
@@ -59,6 +151,21 @@ export default {
 </script>
 
 <style scoped>
+/* 컬럼의 너비 */
+.label {width: 20%;}
+.content { /* 자동으로 맞춰집니다 */ }
+#title2 {
+    color:#6e91b3;
+    background-color: #e4f1f8;
+    font-weight: bold;
+    width: 95px;
+}
+td {
+  color: rgb(34, 34, 34);
+  font-size:14px;
+  height: 30px;
+}
+
 div {
   -webkit-user-select:none;
   -moz-user-select:none;
@@ -70,6 +177,8 @@ a {
 }
 h3 {
     margin: 10px;
+    color:#18225c;
+    padding: 10px 0px 10px 2px;
 }
 .hotelName {
     margin: 50px 50px 10px 50px;
@@ -89,7 +198,6 @@ h3 {
     padding: 5px 8px;
     margin: 30px;
     font-size: 14px;
-    font-weight: bold;
     outline: none;
 }
 .hotelInfo {
@@ -104,7 +212,6 @@ h3 {
     padding: 5px 8px;
     margin: 30px;
     font-size: 14px;
-    font-weight: bold;
     outline: none;
 }
 .hotelAddress {
@@ -119,7 +226,6 @@ input[id="postcode"] {
     padding: 5px 8px;
     margin: 30px 0px 0px 35px;
     font-size: 14px;
-    font-weight: bold;
     outline: none;
 }
 input[id="address"] {
@@ -127,7 +233,6 @@ input[id="address"] {
     padding: 5px 8px;
     margin: 0px 0px 0px 35px;
     font-size: 14px;
-    font-weight: bold;
     outline: none;
 }
 .hotelImg {

--- a/frontend/src/views/hotel/HotelListPage.vue
+++ b/frontend/src/views/hotel/HotelListPage.vue
@@ -1,7 +1,7 @@
 <template>
 <div align="center">
 <v-container>
-    <table style="width: 80%">
+    <table style="width: 100%">
       <tr>
         <td align="left" colspan="2">
       <h2 class="pageTit">숙소 관리</h2>
@@ -12,7 +12,7 @@
             <span class="page-count">전체</span>
         </td>
         <td align="right">
-          <router-link :to="{ name: 'BHotelRegisterPage' }" class="btn"><v-btn>숙소등록</v-btn></router-link>
+          <router-link :to="{ name: 'BHotelRegisterPage' }" class="btn"><button  id="button" >숙소등록</button></router-link>
         </td>
       </tr>
       <tr>

--- a/frontend/src/views/hotel/HotelReadPage.vue
+++ b/frontend/src/views/hotel/HotelReadPage.vue
@@ -1,16 +1,43 @@
 <template>
-<div>
-    <h2>숙소 읽기</h2>
-    <hotel-read v-if="bmHotel" :bmHotel="bmHotel"/>
-    <p v-else>로딩중 입니다.</p>
-    
-    <router-link :to="{ name: 'BHotelModifyPage', params: { hotelNo } }">
-            수정
-        </router-link>
-     <button @click="onDelete">삭제</button>
-     <router-link :to="{ name: 'BHotelListPage' }">
-            목록
-    </router-link>   
+<div align="center">
+
+    <table style="width: 900px;">
+        <tr>
+            <td>
+                <h2 class="pageTit">{{bmHotel.hotelName}} 상세 정보</h2>  
+            </td>
+            <td align="center">
+                <router-link :to="{ name: 'BHotelListPage' }">
+                    <button id="button"> 목록 </button>
+                </router-link>  
+            </td>
+        </tr>
+
+        <tr>
+            <td colspan="2">
+                <hotel-read v-if="bmHotel" :bmHotel="bmHotel"/>
+                <p v-else>로딩중 입니다.</p>
+                <br>
+                <br>
+            </td>
+        </tr>
+
+        <tr>
+            <td>
+                <router-link :to="{ name: 'BHotelModifyPage', params: { hotelNo } }">
+                       <button id="button"> 수정 </button>
+                    </router-link>
+            </td>
+            <td align="right">
+                <button id="button" @click="onDelete">삭제</button>
+            </td>
+        </tr>
+ 
+    </table>
+
+
+    <br>
+
 </div>
 </template>
 
@@ -57,5 +84,36 @@ export default {
 </script>
 
 <style>
+.pageTit {
+  padding: 50px 0px 30px 0px;
+  font-family: 'NanumSquareRound';
+  font-size: 2.0rem;
+  line-height: 1.25;
+  letter-spacing: -.01em;
+  color: #202020;
+  font-weight: 900;
+}
+.pageTit:after {
+    content: '';
+    display: inline-block;
+    width: 4px;
+    height: 4px;
+    margin-bottom: 24px;
+    border-radius: 50%;
+    background-color: #e63668;
+}
 
+#button {
+    text-decoration: none;
+    position: relative;
+    padding: 0 15px;
+    color: #404040;
+    font-weight: 600;
+    font-size: 15px;
+    line-height: 29px;
+}
+
+#button:hover {
+  color: #569aff;
+}
 </style>

--- a/frontend/src/views/room/RoomListPage.vue
+++ b/frontend/src/views/room/RoomListPage.vue
@@ -38,7 +38,7 @@
                     :to="{ name: 'RoomRegisterPage', params: { hotelNo: this.hotelNo.toString() }, }"
                     class="btn">
 
-                  <v-btn>객실등록</v-btn>
+                  <button id="button">객실등록</button>
                 </router-link>
           </td>
         </tr>

--- a/frontend/src/views/room/RoomReadPage.vue
+++ b/frontend/src/views/room/RoomReadPage.vue
@@ -1,15 +1,42 @@
 <template>
-<div>
-    <h2>숙소 읽기</h2>
-    <room-read v-if="bmRoom" :bmRoom="bmRoom"/>
-    <p v-else>로딩중 입니다.</p>
-    <router-link :to="{ name: 'BRoomModifyPage', params: { roomNo } }">
-            수정
-        </router-link>
-     <button @click="onDelete">삭제</button>
-     <router-link :to="{ name: 'BRoomListPage' }">
-            목록
-        </router-link>
+<div align="center">
+
+    <table style="width: 900px;">
+        <tr>
+            <td>
+                <h2 class="pageTit">{{bmRoom.roomType}} 상세 정보</h2>  
+            </td>
+            <td align="center">
+                <router-link :to="{ name: 'BRoomListPage' }">
+                    <button id="button"> 목록 </button>
+                </router-link>  
+            </td>
+        </tr>
+
+        <tr>
+            <td colspan="2">
+                <room-read v-if="bmRoom" :bmRoom="bmRoom"/>
+                <p v-else>로딩중 입니다.</p>
+                <br>
+                <br>
+            </td>
+        </tr>
+
+        <tr>
+            <td>
+                <router-link :to="{ name: 'BRoomModifyPage', params: { roomNo } }">
+                       <button id="button"> 수정 </button>
+                    </router-link>
+            </td>
+            <td align="right">
+                <button id="button" @click="onDelete">삭제</button>
+            </td>
+        </tr>
+ 
+    </table>
+
+    <br>
+
 </div>
 </template>
 


### PR DESCRIPTION
**2022.07.06**
- 사업자 페이지의 숙소&객실 상세보기 UI 정돈 완료
- 사업자 - 예약 관리 페이지 UI 사라져 다시 삽입 + 상세보기 버튼 변경 + 페이지네이션 기능 삽입
- Tag&Common 검색 페이지의 페이지네이션, 페이지당 6개가 나오도록 변경하였음.
- 페이지 네이션 숫자에 Style 먹는 페이지 없도록 span 에 달린 class 제거
- 숙소 상세보기
  - 좋아요의 하트 버튼 외곽선 없애고 클릭 시, 웹 페이지의 포인트 컬러로 변하도록 수정
  - 숙소명 H1 태그 웹 타이틀과 동일한 폰트로 변경, hotel Info 태그 웹 메인의 태그 서치와 양식 비슷하게 변경
  - kakaoMapApi의 기본 width 사이즈를 늘렸음
- 숙소 상세보기의 객실 소개
  - 태그를 웹 메인의 태그 서치와 양식 비슷하게 변경
  - 객실사진 상세보기&예약하기 버튼 마우스오버 효과 삽입
  - roomType 출력되는 부분 p태그가 아니라 h4 사용할 수 있도록 변경 
- 예약&결제하기 페이지
  - 결제하기 버튼 마우스 오버되면 컬러 변경되도록 효과 삽입

**2022.07.07**
- 사업자 - 숙소&객실 관리 List 페이지 버튼 형식 통일